### PR TITLE
counter now displays accurately

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -3,8 +3,9 @@
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
-        <option name="distributionType" value="DEFAULT_WRAPPED" />
+        <option name="distributionType" value="LOCAL" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
+        <option name="gradleHome" value="C:\Program Files\Android\Android Studio\gradle\gradle-2.14.1" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -2,7 +2,7 @@
 <project version="4">
   <component name="ProjectModuleManager">
     <modules>
-      <module fileurl="file://$PROJECT_DIR$/436MsClinicalMonitoring.iml" filepath="$PROJECT_DIR$/436MsClinicalMonitoring.iml" />
+      <module fileurl="file://$PROJECT_DIR$/436MsClinicalMonitoring-.iml" filepath="$PROJECT_DIR$/436MsClinicalMonitoring-.iml" />
       <module fileurl="file://$PROJECT_DIR$/app/app.iml" filepath="$PROJECT_DIR$/app/app.iml" />
     </modules>
   </component>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$" vcs="Git" />
-    <mapping directory="$PROJECT_DIR$" vcs="Git" />
-  </component>
-</project>

--- a/app/src/main/java/com/example/alexandraboukhvalova/a436msclinicalmonitoring/TimingActivity.java
+++ b/app/src/main/java/com/example/alexandraboukhvalova/a436msclinicalmonitoring/TimingActivity.java
@@ -142,6 +142,7 @@ public class TimingActivity extends AppCompatActivity {
                 /* Brian display first 10 second timer*/
                 performTrialTiming();
                 currEvent.setText("LEFT HAND TRIAL 1");
+                resetCounter();
                 tapHearing();
             }else if(secs == 17) {
                 RelativeLayout allScreen = (RelativeLayout) findViewById(R.id.activity_timing);
@@ -158,6 +159,7 @@ public class TimingActivity extends AppCompatActivity {
                 allScreen.setClickable(true);
                 performTrialTiming();
                 currEvent.setText("LEFT HAND TRIAL 2");
+                resetCounter();
                 tapHearing();
             } else if (secs == 31) {
                 /* display tap count from left hand trial 1*/
@@ -205,5 +207,9 @@ public class TimingActivity extends AppCompatActivity {
         TextView counterDisplay = (TextView) findViewById(R.id.tapCounterTextView);
         counterDisplay.setVisibility(View.VISIBLE);
         counterDisplay.setText("Number of recorded taps: "+counter[0]);
+    }
+
+    public void resetCounter() {
+        counter[0] = 0;
     }
 }


### PR DESCRIPTION
added a function to reset the counter before trials begine
-I think the trial displays a message to start trial a second before the trial actually begins? I'll look deeper into it